### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/src/analyzer/code_analyzer.py
+++ b/src/analyzer/code_analyzer.py
@@ -923,7 +923,7 @@ Format response as JSON matching the Vulnerability model structure.
         if not re.match(r'^https?://', repo_url):
             raise ValueError("Invalid repository URL")
 
-        repo_name = repo_url.split('/')[-1].replace('.git', '')
+        repo_name = re.sub(r'[^a-zA-Z0-9_\-]', '_', repo_url.split('/')[-1].replace('.git', ''))
 
         # Get system-appropriate temporary directory
         if os.name == 'nt':  # Windows
@@ -934,7 +934,7 @@ Format response as JSON matching the Vulnerability model structure.
         repo_path = os.path.normpath(os.path.join(temp_dir, repo_name))
 
         # Ensure the repo_path is within the temp directory
-        if not os.path.commonprefix([temp_dir, repo_path]) == temp_dir:
+        if not repo_path.startswith(os.path.normpath(temp_dir)):
             raise ValueError("Invalid repository path")
 
         if os.path.exists(repo_path):


### PR DESCRIPTION
Potential fix for [https://github.com/shivamsaraswat/secora/security/code-scanning/5](https://github.com/shivamsaraswat/secora/security/code-scanning/5)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. This can be achieved by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. Additionally, we should use a more restrictive validation method to ensure that the repository name does not contain any special characters or path traversal sequences.

1. Normalize the `repo_path` using `os.path.normpath`.
2. Ensure that the normalized `repo_path` starts with the temporary directory path.
3. Use a more restrictive validation method to sanitize the repository name.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
